### PR TITLE
Create allocate/free functions for testing

### DIFF
--- a/tests/common.c
+++ b/tests/common.c
@@ -41,3 +41,11 @@ void setup() {
     last_response_was_received = false;
 }
 
+uint8_t* allocate(size_t size) {
+    return (uint8_t*) malloc((sizeof(uint8_t))* size);
+}
+
+void free_allocated(uint8_t* data) {
+    free(data);
+}
+


### PR DESCRIPTION
allocate() and free_allocated() are used by isotp-c to allocate buffers for
multi-frame packets

Signed-off-by: Anton Gerasimov <anton@advancedtelematic.com>